### PR TITLE
Add support for tunnel remotes

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -51,6 +51,7 @@ async function getLatency(remoteEnvName: string): Promise<number> {
     case 'wsl':
     case 'wsl-remote':
     case 'containers-remote':
+    case 'tunnel':
       return await getRemoteContainerLatency();
     default:
       return await getRemoteLatencyWithDefaultFS();


### PR DESCRIPTION
Currently, while connecting to a remote via a tunnel, the extension measures an unrealistic less than a millisecond latency; with this PR it will correctly measure the latency (~70ms for me).

Tunnels can be created by the `ms-vscode.remote-server` extension.